### PR TITLE
fix: prevent error when no queue exits

### DIFF
--- a/src/slash_commands/music/nowplaying.js
+++ b/src/slash_commands/music/nowplaying.js
@@ -10,6 +10,18 @@ module.exports.run = async ({ main_interaction, bot }) => {
     });
 
     const queue = await musicApi.getQueue();
+    if (!queue) {
+        return main_interaction.followUp({
+            embeds: [
+                new EmbedBuilder()
+                    .setDescription(
+                        global.t.trans(['error.music.nothingInQueue'], main_interaction.guild.id)
+                    )
+                    .setColor(global.t.trans(['general.colors.error'])),
+            ],
+            ephemeral: true,
+        });
+    }
 
     if ((await !musicApi.isPlaying()) || (await musicApi.isPaused()))
         return main_interaction.followUp({


### PR DESCRIPTION
## Changes & Bug fixes
<!-- Describe what has changed or fixed in this version -->
- fix an error when executing /nowplaying and no queue exits

Type of change:
- [ ] This PR includes only documentation changes, no code change.
- [x] This PR introduces only smaller Bug fixes. Code should work as before and there's no new Dependencies
- [ ] This PR introduces some Breaking changes, which changes the way how some code works
- [ ] This PR introduces a new feature