### PR TITLE
fix: remove permissions when the bot has no permissions in the channel

### DIFF
--- a/utils/classes/Notifications/Notifications.js
+++ b/utils/classes/Notifications/Notifications.js
@@ -38,6 +38,9 @@ module.exports = class Notification {
                         );
                     } else if (type === 'twitch') {
                         new TwitchNotifier().delete(channel.guild.id, channel_id);
+                        return reject(
+                            'I do not have permission to send messages in that channel. I have removed the channel from the Twitch settings.'
+                        );
                     }
                 }
                 return reject(err);

--- a/utils/classes/Notifications/Twitch/TwitchLogic.js
+++ b/utils/classes/Notifications/Twitch/TwitchLogic.js
@@ -296,7 +296,7 @@ module.exports = class TwitchNotifier {
                 .then(() => {
                     resolve(global.t.trans(['success.notifications.twitch.removed'], guild_id));
                 })
-                .catch((err) => {
+                .catch(() => {
                     reject(global.t.trans(['error.notifications.twitch.removeChannel'], guild_id));
                 });
         });

--- a/utils/classes/Notifications/Twitch/TwitchNotification.js
+++ b/utils/classes/Notifications/Twitch/TwitchNotification.js
@@ -111,6 +111,7 @@ module.exports = class TwitchNotification extends TwitchNotifier {
                         message = await this.sendTwitchNotification(messageContent, embed, {
                             dc_channel: dcChannel,
                             link: `https://twitch.tv/${stream.userDisplayName}`,
+                            twitch_id: data.twitch_id,
                         });
                     }
                     if (!(message instanceof Message)) {
@@ -248,7 +249,7 @@ module.exports = class TwitchNotification extends TwitchNotifier {
         });
     }
 
-    sendTwitchNotification(content, embed, { dc_channel, link }) {
+    sendTwitchNotification(content, embed, { dc_channel, link, twitch_id }) {
         return new Promise(async (resolve, reject) => {
             this.notificationApi
                 .sendNotification({
@@ -264,6 +265,8 @@ module.exports = class TwitchNotification extends TwitchNotifier {
                                 .setEmoji('🔴')
                         ),
                     ],
+                    channel_id: twitch_id,
+                    type: 'twitch',
                 })
                 .then((message) => {
                     console.info(`🔎 Twitch stream handler checked streamer: ${link}...`);

--- a/utils/classes/Notifications/YouTube/YouTubeNotification.js
+++ b/utils/classes/Notifications/YouTube/YouTubeNotification.js
@@ -92,6 +92,8 @@ module.exports = class YouTubeNotification extends YouTubeLogic {
                         channel,
                         content: embedContent,
                         embed: embed,
+                        channel_id: upload.channel_id,
+                        type: 'yt',
                     });
 
                     if (!message || !message.id) continue;


### PR DESCRIPTION
## Changes & Bug fixes
<!-- Describe what has changed or fixed in this version -->
- remove the twitch/yt notification setting when the bot gets a 403 message while trying to send the upload message.


Type of change:
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces only smaller Bug fixes. Code should work as before and there's no new Dependencies
- [x] This PR introduces some Breaking changes, which changes the way how some code works
- [ ] This PR introduces a new feature